### PR TITLE
Make numpy and ipython optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,3 +72,15 @@ Unfortunately, for the time being, our type hints only work with ``pyright``.
 ## Read the docs!
 
 Checkout [https://dougmercer.github.io/signified](https://dougmercer.github.io/signified) to find out more.
+
+## Optional features
+
+`signified` has some support for numpy and IPython built in.
+
+Specify while installing like this, or just have numpy/ipython installed!
+
+```bash
+pip install signified[numpy] # just numpy
+pip install signified[ipython] # just ipython
+pip install signified[all] # both
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,26 +5,23 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "signified"
 version = "0.1.5"
-dependencies = [
-    "ipython",
-    "numpy",
-    "typing-extensions; python_version < '3.11'"
-]
+dependencies = ["typing-extensions; python_version < '3.11'"]
 requires-python = ">=3.9"
-authors = [
-    {name = "Doug Mercer", email = "dougmerceryt@gmail.com"},
-]
-maintainers = [
-    {name = "Doug Mercer", email = "dougmerceryt@gmail.com"},
-]
+authors = [{ name = "Doug Mercer", email = "dougmerceryt@gmail.com" }]
+maintainers = [{ name = "Doug Mercer", email = "dougmerceryt@gmail.com" }]
 description = "Reactive Signals and Computed values."
 readme = "README.md"
-license = {file="LICENSE"}
+license = { file = "LICENSE" }
 keywords = ["reactive", "signals"]
 classifiers = [
     "Development Status :: 3 - Alpha",
     "Programming Language :: Python",
 ]
+
+[project.optional-dependencies]
+numpy = ["numpy"]
+ipython = ["ipython"]
+all = ["numpy", "ipython"]
 
 [tool.setuptools.package-data]
 signified = ["py.typed"]
@@ -123,13 +120,8 @@ docstring-code-line-length = "dynamic"
 
 [tool.pytest.ini_options]
 addopts = "--doctest-modules --cov=src/ --cov-report=xml --junitxml=junit/test-results.xml"
-filterwarnings = [
-    "ignore::DeprecationWarning",
-]
-testpaths = [
-	"tests",
-    "src"
-]
+filterwarnings = ["ignore::DeprecationWarning"]
+testpaths = ["tests", "src"]
 
 [tool.pydocstyle]
 convention = "google"


### PR DESCRIPTION
This PR makes numpy and ipython into optional dependencies, and allows them to type-check properly.

Also resolves some minor issues for eventual mypy support (didn't want to separate these...)

Closes:
- #6
- #11 