### PR TITLE
Add mypy support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -134,3 +134,7 @@ testpaths = [
 [tool.pydocstyle]
 convention = "google"
 add_ignore = ["D107"]
+
+[tool.mypy]
+strict = true
+allow_redefinition = true

--- a/src/signified/__init__.py
+++ b/src/signified/__init__.py
@@ -532,7 +532,7 @@ class Variable(ABC, Flattener[T]):
         f: Callable[[T, Y], T | Y] = operator.add
         return computed(f)(self, other)
 
-    def __and__(self, other: HasValue[Y]) -> Computed[bool]:
+    def __and__(self, other: HasValue[Y]) -> Computed[int]:
         """Return a reactive value for the bitwise AND of self and other.
 
         Args:
@@ -767,7 +767,7 @@ class Variable(ABC, Flattener[T]):
         """
         return computed(operator.lt)(self, other)
 
-    def __lshift__(self, other: HasValue[Y]) -> Computed[T | Y]:
+    def __lshift__(self, other: int | HasValue[int]) -> Computed[int]:
         """Return a reactive value for `self` left-shifted by `other`.
 
         Args:
@@ -788,8 +788,7 @@ class Variable(ABC, Flattener[T]):
 
             ```
         """
-        f: Callable[[T, Y], T | Y] = operator.lshift
-        return computed(f)(self, other)
+        return cast(Computed[int], computed(operator.lshift)(self, other))
 
     def __matmul__(self, other: HasValue[Y]) -> Computed[T | Y]:
         """Return a reactive value for the matrix multiplication of `self` and `other`.
@@ -887,7 +886,7 @@ class Variable(ABC, Flattener[T]):
         """
         return computed(operator.ne)(self, other)
 
-    def __or__(self, other: Any) -> Computed[bool]:
+    def __or__(self, other: Any) -> Computed[int]:
         """Return a reactive value for the bitwise OR of `self` and `other`.
 
         Args:
@@ -910,7 +909,7 @@ class Variable(ABC, Flattener[T]):
         """
         return computed(operator.or_)(self, other)
 
-    def __rshift__(self, other: HasValue[Y]) -> Computed[T | Y]:
+    def __rshift__(self, other: int | HasValue[int]) -> Computed[int]:
         """Return a reactive value for `self` right-shifted by `other`.
 
         Args:
@@ -931,8 +930,7 @@ class Variable(ABC, Flattener[T]):
 
             ```
         """
-        f: Callable[[T, Y], T | Y] = operator.rshift
-        return computed(f)(self, other)
+        return cast(Computed[int], computed(operator.rshift)(self, other))
 
     def __pow__(self, other: HasValue[Y]) -> Computed[T | Y]:
         """Return a reactive value for `self` raised to the power of `other`.
@@ -1006,7 +1004,7 @@ class Variable(ABC, Flattener[T]):
         f: Callable[[T, Y], T | Y] = operator.truediv
         return computed(f)(self, other)
 
-    def __xor__(self, other: Any) -> Computed[bool]:
+    def __xor__(self, other: Any) -> Computed[int]:
         """Return a reactive value for the bitwise XOR of `self` and `other`.
 
         Args:
@@ -1053,7 +1051,7 @@ class Variable(ABC, Flattener[T]):
         f: Callable[[Y, T], T | Y] = operator.add
         return computed(f)(other, self)
 
-    def __rand__(self, other: Any) -> Computed[bool]:
+    def __rand__(self, other: Any) -> Computed[int]:
         """Return a reactive value for the bitwise AND of `self` and `other`.
 
         Args:
@@ -1171,7 +1169,7 @@ class Variable(ABC, Flattener[T]):
         f: Callable[[Y, T], T | Y] = operator.mul
         return computed(f)(other, self)
 
-    def __ror__(self, other: Any) -> Computed[bool]:
+    def __ror__(self, other: Any) -> Computed[int]:
         """Return a reactive value for the bitwise OR of `self` and `other`.
 
         Args:
@@ -1266,7 +1264,7 @@ class Variable(ABC, Flattener[T]):
         f: Callable[[Y, T], T | Y] = operator.truediv
         return computed(f)(other, self)
 
-    def __rxor__(self, other: Any) -> Computed[bool]:
+    def __rxor__(self, other: Any) -> Computed[int]:
         """Return a reactive value for the bitwise XOR of `self` and `other`.
 
         Args:

--- a/src/signified/__init__.py
+++ b/src/signified/__init__.py
@@ -23,6 +23,7 @@ Attributes:
 
 from __future__ import annotations
 
+import builtins
 import math
 import operator
 from contextlib import contextmanager
@@ -316,7 +317,7 @@ class Variable(ABC, Flattener[T]):
         """
         return computed(abs)(self)
 
-    def bool(self) -> Computed[bool]:
+    def bool(self) -> Computed[builtins.bool]:
         """Return a reactive value for the boolean value of `self`.
 
         Note:
@@ -555,7 +556,7 @@ class Variable(ABC, Flattener[T]):
         """
         return computed(operator.and_)(self, other)
 
-    def contains(self, other: Any) -> Computed[bool]:
+    def contains(self, other: Any) -> Computed[builtins.bool]:
         """Return a reactive value for whether `other` is in `self`.
 
         Args:
@@ -601,7 +602,7 @@ class Variable(ABC, Flattener[T]):
         """
         return cast(Computed[tuple[float, float]], computed(divmod)(self, other))
 
-    def is_not(self, other: Any) -> Computed[bool]:
+    def is_not(self, other: Any) -> Computed[builtins.bool]:
         """Return a reactive value for whether `self` is not other.
 
         Args:
@@ -625,7 +626,7 @@ class Variable(ABC, Flattener[T]):
         """
         return computed(operator.is_not)(self, other)
 
-    def eq(self, other: Any) -> Computed[bool]:
+    def eq(self, other: Any) -> Computed[builtins.bool]:
         """Return a reactive value for whether `self` equals other.
 
         Args:
@@ -675,7 +676,7 @@ class Variable(ABC, Flattener[T]):
         f: Callable[[T, Y], T | Y] = operator.floordiv
         return computed(f)(self, other)
 
-    def __ge__(self, other: Any) -> Computed[bool]:
+    def __ge__(self, other: Any) -> Computed[builtins.bool]:
         """Return a reactive value for whether `self` is greater than or equal to other.
 
         Args:
@@ -698,7 +699,7 @@ class Variable(ABC, Flattener[T]):
         """
         return computed(operator.ge)(self, other)
 
-    def __gt__(self, other: Any) -> Computed[bool]:
+    def __gt__(self, other: Any) -> Computed[builtins.bool]:
         """Return a reactive value for whether `self` is greater than other.
 
         Args:
@@ -721,7 +722,7 @@ class Variable(ABC, Flattener[T]):
         """
         return computed(operator.gt)(self, other)
 
-    def __le__(self, other: Any) -> Computed[bool]:
+    def __le__(self, other: Any) -> Computed[builtins.bool]:
         """Return a reactive value for whether `self` is less than or equal to `other`.
 
         Args:
@@ -744,7 +745,7 @@ class Variable(ABC, Flattener[T]):
         """
         return computed(operator.le)(self, other)
 
-    def __lt__(self, other: Any) -> Computed[bool]:
+    def __lt__(self, other: Any) -> Computed[builtins.bool]:
         """Return a reactive value for whether `self` is less than `other`.
 
         Args:
@@ -863,7 +864,7 @@ class Variable(ABC, Flattener[T]):
         f: Callable[[T, Y], T | Y] = operator.mul
         return computed(f)(self, other)
 
-    def __ne__(self, other: Any) -> Computed[bool]:  # type: ignore[override]
+    def __ne__(self, other: Any) -> Computed[builtins.bool]:  # type: ignore[override]
         """Return a reactive value for whether `self` is not equal to `other`.
 
         Args:

--- a/tests/test_computed.py
+++ b/tests/test_computed.py
@@ -1,7 +1,7 @@
 from signified import Signal, Computed, computed
 
 
-def test_computed_basic():
+def test_computed_basic() -> None:
     """Test basic Computed functionality."""
     s = Signal(5)
     c = Computed(lambda: s.value * 2, dependencies=[s])
@@ -12,12 +12,12 @@ def test_computed_basic():
     assert c.value == 14
 
 
-def test_computed_decorator():
+def test_computed_decorator() -> None:
     """Test the @computed decorator."""
     s = Signal(5)
 
     @computed
-    def double_it(x):
+    def double_it(x: int) -> int:
         return x * 2
 
     c = double_it(s)
@@ -27,13 +27,13 @@ def test_computed_decorator():
     assert c.value == 14
 
 
-def test_computed_dependencies():
+def test_computed_dependencies() -> None:
     """Test Computed with multiple dependencies."""
     s1 = Signal(5)
     s2 = Signal(10)
 
     @computed
-    def add_em(a, b):
+    def add_em(a: int, b: int) -> int:
         return a + b
 
     c = add_em(s1, s2)
@@ -46,13 +46,13 @@ def test_computed_dependencies():
     assert c.value == 20
 
 
-def test_computed_with_nested_signals():
+def test_computed_with_nested_signals() -> None:
     """Test Computed with multiple nested Signals."""
     s1 = Signal(Signal(5))
     s2 = Signal(Signal(Signal(3)))
 
     @computed
-    def complex_computation(a, b):
+    def complex_computation(a: float, b: float) -> float:
         return a * b
 
     result = complex_computation(s1, s2)
@@ -62,7 +62,7 @@ def test_computed_with_nested_signals():
     assert result.value == 21
 
 
-def test_computed_chaining():
+def test_computed_chaining() -> None:
     """Test chaining of Computed values."""
     s = Signal(5)
     c1 = computed(lambda x: x * 2)(s)

--- a/tests/test_reactive_methods.py
+++ b/tests/test_reactive_methods.py
@@ -3,7 +3,7 @@ from signified import Signal
 import math
 
 
-def test_signal_arithmetic():
+def test_signal_arithmetic() -> None:
     """Test Signal arithmetic operations."""
     s1 = Signal(5)
     s2 = Signal(10)
@@ -15,7 +15,7 @@ def test_signal_arithmetic():
     assert sum_computed.value == 17
 
 
-def test_signal_comparison():
+def test_signal_comparison() -> None:
     """Test Signal comparison operations."""
     s1 = Signal(5)
     s2 = Signal(10)
@@ -27,7 +27,7 @@ def test_signal_comparison():
     assert gt_computed.value == False  # noqa: E712
 
 
-def test_signal_arithmetic_operations():
+def test_signal_arithmetic_operations() -> None:
     """Test various arithmetic operations on Signals."""
     s1 = Signal(5)
     s2 = Signal(3)
@@ -41,7 +41,7 @@ def test_signal_arithmetic_operations():
     assert (s1**s2).value == 125
 
 
-def test_signal_comparison_operations():
+def test_signal_comparison_operations() -> None:
     """Test comparison operations on Signals."""
     s1 = Signal(5)
     s2 = Signal(3)
@@ -54,7 +54,7 @@ def test_signal_comparison_operations():
     assert (s1 != s2).value == True  # noqa: E712
 
 
-def test_signal_boolean_operations():
+def test_signal_boolean_operations() -> None:
     """Test boolean operations on Signals."""
     s1 = Signal(True)
     s2 = Signal(False)
@@ -65,7 +65,7 @@ def test_signal_boolean_operations():
     assert (s1 ^ s1).value == False  # noqa: E712
 
 
-def test_signal_bitwise_operations():
+def test_signal_bitwise_operations() -> None:
     """Test bitwise operations on Signals."""
     s1 = Signal(0b0101)  # 5 in binary
     s2 = Signal(0b0011)  # 3 in binary
@@ -78,7 +78,7 @@ def test_signal_bitwise_operations():
     assert (s1 >> 1).value == 0b0010  # Right shift
 
 
-def test_signal_inplace_operations():
+def test_signal_inplace_operations() -> None:
     """Test in-place operations on Signals."""
     s = Signal(5)
 
@@ -92,11 +92,11 @@ def test_signal_inplace_operations():
     assert s.value == 5
 
 
-def test_signal_attribute_access():
+def test_signal_attribute_access() -> None:
     """Test attribute access on Signal containing an object."""
 
     class MyObj:
-        def __init__(self):
+        def __init__(self) -> None:
             self.x = 5
             self.y = 10
 
@@ -106,14 +106,14 @@ def test_signal_attribute_access():
     assert s.y.value == 10
 
 
-def test_signal_method_call():
+def test_signal_method_call() -> None:
     """Test method calls on Signal containing an object."""
 
     class MyObj:
-        def __init__(self, value):
+        def __init__(self, value: float) -> None:
             self.value = value
 
-        def double(self):
+        def double(self) -> float:
             return self.value * 2
 
     s = Signal(MyObj(5))
@@ -121,7 +121,7 @@ def test_signal_method_call():
     assert s.double().value == 10
 
 
-def test_signal_indexing():
+def test_signal_indexing() -> None:
     """Test indexing on Signal containing a sequence."""
     s = Signal([1, 2, 3, 4, 5])
 
@@ -130,7 +130,7 @@ def test_signal_indexing():
     assert s[1:4].value == [2, 3, 4]
 
 
-def test_signal_contains():
+def test_signal_contains() -> None:
     """Test 'in' operator on Signal containing a sequence."""
     s = Signal([1, 2, 3, 4, 5])
 
@@ -138,7 +138,7 @@ def test_signal_contains():
     assert s.contains(6).value == False  # noqa: E712
 
 
-def test_signal_bool():
+def test_signal_bool() -> None:
     """Test boolean evaluation of Signal."""
     s1 = Signal(1)
     s2 = Signal(0)
@@ -151,7 +151,7 @@ def test_signal_bool():
     assert s4.bool().value == True  # noqa: E712
 
 
-def test_signal_math_functions():
+def test_signal_math_functions() -> None:
     """Test math functions on Signals."""
     s = Signal(15.1)
 
@@ -164,7 +164,7 @@ def test_signal_math_functions():
     assert abs(s).value == 15.1
 
 
-def test_signal_where():
+def test_signal_where() -> None:
     """Test the 'where' method on Signals."""
     condition = Signal(True)
     s1 = Signal(5)

--- a/tests/test_reactive_methods.py
+++ b/tests/test_reactive_methods.py
@@ -142,7 +142,7 @@ def test_signal_bool() -> None:
     """Test boolean evaluation of Signal."""
     s1 = Signal(1)
     s2 = Signal(0)
-    s3 = Signal([])
+    s3 = Signal([])  # type: ignore[var-annotated]
     s4 = Signal([1, 2, 3])
 
     assert s1.bool().value == True  # noqa: E712

--- a/tests/test_signals.py
+++ b/tests/test_signals.py
@@ -1,7 +1,8 @@
 from signified import Signal, Computed, unref
+from typing import Any
 
 
-def test_signal_basic():
+def test_signal_basic() -> None:
     """Test basic Signal functionality."""
     s = Signal(5)
     assert s.value == 5
@@ -10,7 +11,7 @@ def test_signal_basic():
     assert s.value == 10
 
 
-def test_signal_nested():
+def test_signal_nested() -> None:
     """Test nested Signal functionality."""
     s1 = Signal(5)
     s2 = Signal(s1)
@@ -22,7 +23,7 @@ def test_signal_nested():
     assert s3.value == 10
 
 
-def test_unref():
+def test_unref() -> None:
     """Test the unref function."""
     s = Signal(5)
     c = Computed(lambda: s.value * 2, dependencies=[s])
@@ -32,18 +33,18 @@ def test_unref():
     assert unref(15) == 15
 
 
-def test_signal_observer():
+def test_signal_observer() -> None:
     """Test Signal observer pattern."""
     s = Signal(5)
 
     class Appender:
         """An observer that appends values whenever a signal changes."""
 
-        def __init__(self, s: Signal):
+        def __init__(self, s: Signal[Any]) -> None:
             self.s = s
-            self.values = []
+            self.values: list[Any] = []
 
-        def update(self):
+        def update(self) -> None:
             self.values.append(self.s.value)
 
     appender = Appender(s)
@@ -55,7 +56,7 @@ def test_signal_observer():
     assert appender.values == [10, 15]
 
 
-def test_signal_context_manager():
+def test_signal_context_manager() -> None:
     """Test the Signal's context manager functionality."""
     s = Signal(5)
     t = Signal(s)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,7 +1,7 @@
 from signified import Signal, Computed, has_value, unref, reactive_method, as_signal
 
 
-def test_has_value():
+def test_has_value() -> None:
     """Test the has_value type guard function."""
     s = Signal(5)
     c = Computed(lambda: 10)
@@ -12,22 +12,22 @@ def test_has_value():
     assert not has_value(s, str)
 
 
-def test_unref_nested_signals():
+def test_unref_nested_signals() -> None:
     """Test unref function with deeply nested Signals."""
     s = Signal(Signal(Signal(Signal(5))))
     assert unref(s) == 5
 
 
-def test_reactive_method_decorator():
+def test_reactive_method_decorator() -> None:
     """Test the reactive_method decorator."""
 
     class MyClass:
-        def __init__(self):
+        def __init__(self) -> None:
             self.x = Signal(5)
             self.y = Signal(10)
 
         @reactive_method("x", "y")
-        def sum(self):
+        def sum(self) -> int:
             return self.x.value + self.y.value
 
     obj = MyClass()
@@ -38,7 +38,7 @@ def test_reactive_method_decorator():
     assert result.value == 17
 
 
-def test_as_signal():
+def test_as_signal() -> None:
     """Test the as_signal function."""
     s1 = as_signal(5)
     s2 = as_signal(Signal(10))

--- a/tests/type_inference.py
+++ b/tests/type_inference.py
@@ -13,7 +13,7 @@ T = TypeVar("T")
 Numeric = Union[int, float]
 
 
-def test_signal_types():
+def test_signal_types() -> None:
     a = Signal(1)
     assert_type(a, Signal[int])
     assert_type(a.value, int)
@@ -31,7 +31,7 @@ def test_signal_types():
     assert_type(d.value, float)
 
 
-def test_computed_types():
+def test_computed_types() -> None:
     def blah() -> float:
         return 1.1
 
@@ -47,21 +47,21 @@ def test_computed_types():
     assert_type(f.value, int)
 
 
-def test_arithmetic_types():
+def test_arithmetic_types() -> None:
     a = Signal(1)
     b = Signal(2)
     c = Signal(3.0)
 
     result = a + b
     assert_type(result, Computed[int])
-    assert_type(unref(result), int)
+    assert_type(result.value, int)
 
     result = a + c
     assert_type(result, Computed[Numeric])
-    assert_type(unref(result), Numeric)
+    assert_type(result.value, Numeric)
 
 
-def test_comparison_types():
+def test_comparison_types() -> None:
     a = Signal(1)
     b = Signal(Signal(Signal(2)))
 
@@ -70,7 +70,7 @@ def test_comparison_types():
     assert_type(unref(result), bool)
 
 
-def test_where_types():
+def test_where_types() -> None:
     a = Signal(1)
     b = Signal(2.0)
     condition = Signal(True)
@@ -80,7 +80,7 @@ def test_where_types():
     assert_type(unref(result), Numeric)
 
 
-def test_unref_types():
+def test_unref_types() -> None:
     a = Signal(1)
     b = Signal(Signal(2.0))
     c = Computed(lambda: "three")
@@ -90,7 +90,7 @@ def test_unref_types():
     assert_type(unref(c), str)
 
 
-def test_complex_expression_types():
+def test_complex_expression_types() -> None:
     a = Signal(1)
     b = Signal(2.0)
     c = Computed(lambda: 3)
@@ -100,12 +100,12 @@ def test_complex_expression_types():
     assert_type(unref(result), Numeric)
 
 
-def test_call_inference():
+def test_call_inference() -> None:
     class Person:
         def __init__(self, name: str):
             self.name = name
 
-        def __call__(self, formal=False) -> str:
+        def __call__(self, formal: bool=False) -> str:
             return f"{'Greetings' if formal else 'Hi'}, I'm {self.name}!"
 
     a = computed(lambda: Person("Doug"))()


### PR DESCRIPTION
This PR implements and extends changes by @laundmo in #19.

Here is the `mypy` output

```console
$ mypy src/ tests/
tests/type_inference.py:80: error: Expression is of type "float", not "Union[int, float]"  [assert-type]
tests/type_inference.py:100: error: Expression is of type "float", not "Union[int, float]"  [assert-type]
tests/type_inference.py:114: error: Invalid self argument "Computed[Person]" to attribute function "__call__" with type "Callable[[Variable[Callable[P, R]], **P], Computed[R]]"  [misc]
tests/test_reactive_methods.py:105: error: overloaded function has no attribute "value"  [attr-defined]
tests/test_reactive_methods.py:106: error: overloaded function has no attribute "value"  [attr-defined]
tests/test_reactive_methods.py:121: error: All overload variants of "__getattr__" of "Variable" require at least one argument  [call-overload]
tests/test_reactive_methods.py:121: note: Possible overload variants:
tests/test_reactive_methods.py:121: note:     def __getattr__(self, Literal['value'], /) -> MyObj
tests/test_reactive_methods.py:121: note:     def __getattr__(self, Literal['_value'], /) -> Union[Computed[MyObj], Signal[MyObj], Flattener[MyObj]]
tests/test_reactive_methods.py:121: note:     def __getattr__(self, str, /) -> Computed[Any]
```

* mypy is going above and beyond, and seems to be "promoting" a `int | float` to a `float`, which causes some `asset_type` checks to break.
* `mypy` doesn't seem to know how to handle classes that implement `__call__`.
* I have no idea why I'm getting "error: overloaded function has no attribute 'value'" for these cases.
* I have no idea what is going on with the error where it can't find an overload for`__getattr__`.

Beyond that, these changes + using mypy did produce some really strange issues
* In mypy, `Variable.bool()` shadows the builtin `bool` type, so I had to update several return types to use `builtins.bool` explicitly (in order to avoid having to change the method name).
* In both `mypy` and `pyright`, the new `Flattener[T]` approach stopped `lshift` and `rshift` from being type hinted correctly, so I needed to add more explicit input types/casting.

This definitely seems like a huge improvement over not supporting mypy at all.
