### PR TITLE
Make ruff actually enforce isort-like imports.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,7 +83,7 @@ target-version = "py39"
 # Enable Pyflakes (`F`) and a subset of the pycodestyle (`E`)  codes by default.
 # Unlike Flake8, Ruff doesn't enable pycodestyle warnings (`W`) or
 # McCabe complexity (`C901`) by default.
-select = ["E4", "E7", "E9", "F"]
+select = ["E4", "E7", "E9", "F", "I"]
 ignore = []
 
 # Allow fix for all enabled rules (when `--fix`) is provided.

--- a/src/signified/__init__.py
+++ b/src/signified/__init__.py
@@ -25,10 +25,10 @@ from __future__ import annotations
 
 import math
 import operator
-from contextlib import contextmanager
-from functools import wraps
 import sys
 from abc import ABC, abstractmethod
+from contextlib import contextmanager
+from functools import wraps
 from typing import (
     Any,
     Callable,
@@ -46,17 +46,16 @@ from typing import (
 import numpy as np
 from IPython.display import DisplayHandle, display
 
-
 if sys.version_info >= (3, 11):
     from typing import Self
 else:
     from typing_extensions import Self
 
 if sys.version_info >= (3, 10):
-    from typing import TypeAlias, TypeGuard, ParamSpec, Concatenate
+    from typing import Concatenate, ParamSpec, TypeAlias, TypeGuard
 
 else:
-    from typing_extensions import TypeAlias, TypeGuard, ParamSpec, Concatenate
+    from typing_extensions import Concatenate, ParamSpec, TypeAlias, TypeGuard
 
 __all__ = [
     "Variable",

--- a/tests/test_computed.py
+++ b/tests/test_computed.py
@@ -1,4 +1,4 @@
-from signified import Signal, Computed, computed
+from signified import Computed, Signal, computed
 
 
 def test_computed_basic():

--- a/tests/test_reactive_methods.py
+++ b/tests/test_reactive_methods.py
@@ -1,6 +1,6 @@
-from signified import Signal
-
 import math
+
+from signified import Signal
 
 
 def test_signal_arithmetic():

--- a/tests/test_signals.py
+++ b/tests/test_signals.py
@@ -1,4 +1,4 @@
-from signified import Signal, Computed, unref
+from signified import Computed, Signal, unref
 
 
 def test_signal_basic():

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,4 +1,4 @@
-from signified import Signal, Computed, has_value, unref, reactive_method, as_signal
+from signified import Computed, Signal, as_signal, has_value, reactive_method, unref
 
 
 def test_has_value():

--- a/tests/type_inference.py
+++ b/tests/type_inference.py
@@ -1,7 +1,7 @@
 import sys
 from typing import TypeVar, Union
 
-from signified import Signal, Computed, computed, unref
+from signified import Computed, Signal, computed, unref
 
 if sys.version_info >= (3, 11):
     from typing import assert_type


### PR DESCRIPTION
Oops... didn't realize import sorting was enforced by ruff's linter rather than formatter.