### PR TITLE
Add is_reactive typeguard and improve union type inference

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -113,15 +113,20 @@ subscript, and attribute-access operations all return reactive
 ::: signified.computed
 ::: signified.unref
 ::: signified.deep_unref
+::: signified.is_reactive
 ::: signified.has_value
 ::: signified.as_rx
 
 ## Types
 
+### HasValue {#signified.HasValue}
+
 **`HasValue[T]`** — `T | Computed[T] | Signal[T]`
 
 A plain or reactive value that resolves to `T`. Use as a type hint when a
 parameter accepts either a raw value or a reactive wrapper.
+
+### ReactiveValue {#signified.ReactiveValue}
 
 **`ReactiveValue[T]`** — `Computed[T] | Signal[T]`
 

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -6,6 +6,11 @@ hide:
 
 This page summarizes notable changes across releases.
 
+## 0.5.1 (unreleased)
+
+Add `is_reactive` to inspect wrappers without reading their values. Improve
+union inference for `unref` and `as_rx`; runtime resolution is unchanged.
+
 ## 0.5.0
 
 ### Removals

--- a/src/signified/__init__.py
+++ b/src/signified/__init__.py
@@ -13,6 +13,7 @@ Functions:
     computed: Decorator to create a reactive value from a function.
     as_rx: Convert a value to a reactive value if it's not already reactive.
     has_value: Type guard to check if an object has a value of a specific type.
+    is_reactive: Check for a reactive wrapper without reading its value.
 
 Attributes:
     ReactiveValue: Union of Computed and Signal types.
@@ -22,7 +23,7 @@ Attributes:
 # Import _mixin first to initialize _ReactiveMixIn before runtime classes.
 from . import _mixin
 from ._functions import as_rx, computed, deep_unref, effect, has_value, unref
-from ._reactive import Computed, Effect, Signal, Variable
+from ._reactive import Computed, Effect, Signal, Variable, is_reactive
 from ._types import HasValue, ReactiveValue
 
 del _mixin
@@ -39,5 +40,6 @@ __all__ = [
     "HasValue",
     "ReactiveValue",
     "has_value",
+    "is_reactive",
     "deep_unref",
 ]

--- a/src/signified/_functions.py
+++ b/src/signified/_functions.py
@@ -5,9 +5,9 @@ from __future__ import annotations
 import importlib.util
 from collections.abc import Iterable
 from functools import wraps
-from typing import Any, Callable, TypeGuard, cast
+from typing import Any, Callable, TypeGuard, overload
 
-from ._reactive import Computed, Effect, Signal, _is_reactive_value, _track_read
+from ._reactive import Computed, Effect, Signal, _track_read, is_reactive
 from ._types import HasValue, ReactiveValue
 
 if importlib.util.find_spec("numpy") is not None:
@@ -23,7 +23,7 @@ def _identity[T](value: T) -> T:
 
 
 def _get_unref_op(value: Any) -> Callable[[Any], Any]:
-    if _is_reactive_value(value):
+    if is_reactive(value):
         return unref
     if type(value) in _PLAIN_ARG_TYPES:
         return _identity
@@ -133,7 +133,15 @@ def effect(func: Callable[..., None]) -> Callable[..., Effect]:
     return wrapper
 
 
-def unref[T](value: HasValue[T]) -> T:
+@overload
+def unref[T](value: HasValue[T]) -> T: ...
+
+
+@overload
+def unref[T, U](value: HasValue[T] | HasValue[U]) -> T | U: ...
+
+
+def unref(value: Any) -> Any:
     """Unwrap a reactive value to its plain Python value.
 
     Repeatedly follows the `.value` chain until a non-reactive value is
@@ -156,7 +164,7 @@ def unref[T](value: HasValue[T]) -> T:
         ```
     """
     current: Any = value
-    while _is_reactive_value(current):
+    while is_reactive(current):
         if current._IS_COMPUTED:
             current._impl.ensure_uptodate()
         _track_read(current)
@@ -256,7 +264,15 @@ def deep_unref(value: Any) -> Any:
     return value
 
 
-def as_rx[T](val: HasValue[T]) -> ReactiveValue[T]:
+@overload
+def as_rx[T](val: HasValue[T]) -> ReactiveValue[T]: ...
+
+
+@overload
+def as_rx[T, U](val: HasValue[T] | HasValue[U]) -> ReactiveValue[T] | ReactiveValue[U]: ...
+
+
+def as_rx(val: Any) -> ReactiveValue[Any]:
     """Normalize a value to a reactive object.
 
     If `val` is already reactive, it is returned unchanged. Otherwise a new
@@ -268,6 +284,6 @@ def as_rx[T](val: HasValue[T]) -> ReactiveValue[T]:
     Returns:
         A reactive value.
     """
-    if _is_reactive_value(val):
+    if is_reactive(val):
         return val
-    return Signal(cast(T, val))
+    return Signal(val)

--- a/src/signified/_mixin.py
+++ b/src/signified/_mixin.py
@@ -1645,7 +1645,7 @@ class _ReactiveMixIn[T]:
         wrapped = self.value
         if hasattr(wrapped, name):
             setattr(wrapped, name, value)
-            if _is_reactive_value(self):
+            if is_reactive(self):
                 self._bump_version()
                 if HOOKS_ENABLED:
                     plugin_manager.hook.updated(value=self)
@@ -1682,7 +1682,7 @@ class _ReactiveMixIn[T]:
         """
         if isinstance(self.value, (list, dict)):
             self.value[key] = value
-            if _is_reactive_value(self):
+            if is_reactive(self):
                 self._bump_version()
                 if HOOKS_ENABLED:
                     plugin_manager.hook.updated(value=self)
@@ -1693,5 +1693,5 @@ class _ReactiveMixIn[T]:
 
 # Loaded after _ReactiveMixIn is defined to avoid import cycles.
 from ._functions import computed  # noqa: E402
-from ._reactive import Effect, _bump_global_version, _is_reactive_value  # noqa: E402
+from ._reactive import Effect, _bump_global_version, is_reactive  # noqa: E402
 from .plugins import HOOKS_ENABLED, plugin_manager  # noqa: E402

--- a/src/signified/_reactive.py
+++ b/src/signified/_reactive.py
@@ -31,17 +31,35 @@ def _bump_global_version() -> int:
     return _GLOBAL_VERSION
 
 
-def _is_reactive_value[T](value: HasValue[T]) -> TypeGuard[ReactiveValue[T]]:
-    """Return whether ``value`` is a signified reactive wrapper."""
-    # Note: We use a specific attribute instead of isinstance to reduce overhead.
-    return getattr(type(value), "_IS_REACTIVE", False)
+@overload
+def is_reactive[T](obj: HasValue[T]) -> TypeGuard[ReactiveValue[T]]: ...
+
+
+@overload
+def is_reactive[T, U](obj: HasValue[T] | HasValue[U]) -> TypeGuard[ReactiveValue[T] | ReactiveValue[U]]: ...
+
+
+def is_reactive(obj: object) -> bool:
+    """Return whether an object is a signified reactive wrapper.
+
+    This guard narrows a plain-or-reactive [HasValue][signified.HasValue] to
+    [ReactiveValue][signified.ReactiveValue] in the true branch without reading
+    the wrapped value or creating a dependency.
+
+    Args:
+        obj: Value to inspect.
+
+    Returns:
+        `True` for a [Signal][signified.Signal], [Computed][signified.Computed].
+    """
+    return getattr(type(obj), "_IS_REACTIVE", False)
 
 
 def _may_have_reactive_children(value: Any) -> bool:
     """Return whether `value` could contain reactive values that need subscriptions."""
     if type(value) in _PLAIN_SCALAR_TYPES:
         return False
-    if _is_reactive_value(value):
+    if is_reactive(value):
         return True
     return isinstance(value, Iterable) and not isinstance(value, str)
 
@@ -88,7 +106,7 @@ class Variable[T](ABC, _ReactiveMixIn[T]):
         """Yield `Variable` instances found in arbitrarily nested containers."""
         if type(item) in _PLAIN_SCALAR_TYPES:
             return
-        if _is_reactive_value(item):
+        if is_reactive(item):
             yield item
             return
         if isinstance(item, str):
@@ -261,7 +279,7 @@ def _resolve[T](value: HasValue[T]) -> T:
     current: T | HasValue[T] = value
     if type(current) in _PLAIN_SCALAR_TYPES:
         return cast(T, current)
-    while _is_reactive_value(current):
+    while is_reactive(current):
         if current._IS_COMPUTED:
             current._impl.ensure_uptodate()
         current = current._value
@@ -289,7 +307,7 @@ def _has_changed(previous: Any, current: Any) -> bool:
     # Reactive wrappers compare by identity rather than value equality.
     # Distinct wrapper objects should invalidate even if they currently resolve
     # to equal values.
-    if _is_reactive_value(previous) or _is_reactive_value(current):
+    if is_reactive(previous) or is_reactive(current):
         return previous is not current
 
     # Keep NaN stable: treat NaN -> NaN as unchanged.

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,4 +1,4 @@
-from signified import Computed, Signal, as_rx, computed, has_value, unref
+from signified import Computed, Signal, as_rx, computed, has_value, is_reactive, unref
 from signified._reactive import _coerce_to_bool, _has_changed
 
 
@@ -147,3 +147,14 @@ def test_coerce_to_bool_uses_all_fallback():
             return False
 
     assert _coerce_to_bool(AmbiguousBool()) is False
+
+
+def test_is_reactive_does_not_evaluate_or_subscribe():
+    source = Signal(1)
+    lazy = Computed(lambda: (_ for _ in ()).throw(AssertionError("must not evaluate")))
+    assert is_reactive(source)
+    assert is_reactive(lazy)
+    assert not is_reactive(1)
+    observer = Computed(lambda: is_reactive(source))
+    assert observer.value is True
+    assert not source._observers

--- a/tests/type_inference.py
+++ b/tests/type_inference.py
@@ -1,7 +1,7 @@
 from math import ceil, floor, trunc
 from typing import Any, TypeVar, Union, assert_type
 
-from signified import Computed, Effect, Signal, computed, unref
+from signified import Computed, Effect, HasValue, ReactiveValue, Signal, as_rx, computed, is_reactive, unref
 
 T = TypeVar("T")
 Numeric = Union[int, float]
@@ -664,3 +664,25 @@ def test_complex_expression():
     result = (a + b) * c
     assert_type(result, Computed[Numeric])
     assert_type(unref(result), Numeric)
+
+
+def test_is_reactive_positive_narrowing(value: HasValue[int]):
+    if is_reactive(value):
+        assert_type(value, ReactiveValue[int])
+
+
+def test_unref_distributes_over_has_value_union(value: HasValue[int] | HasValue[str]):
+    assert_type(unref(value), int | str)
+
+
+def test_is_reactive_distributes_over_has_value_union(value: HasValue[int] | HasValue[str]):
+    if is_reactive(value):
+        assert_type(value, ReactiveValue[int] | ReactiveValue[str])
+
+
+def test_as_rx_distributes_over_has_value_union(value: HasValue[int] | HasValue[str]):
+    assert_type(as_rx(value), ReactiveValue[int] | ReactiveValue[str])
+
+
+def test_as_rx_distributes_over_larger_union(value: HasValue[int] | HasValue[str] | HasValue[bytes]):
+    assert_type(as_rx(value), ReactiveValue[int] | ReactiveValue[str] | ReactiveValue[bytes])


### PR DESCRIPTION
Preserve union inference without changing recursive unref or the existing Signal and Computed behavior.